### PR TITLE
管理画面サイドバーのスクロール切れ問題を修正

### DIFF
--- a/components/admin/Sidebar.tsx
+++ b/components/admin/Sidebar.tsx
@@ -29,7 +29,7 @@ export default function Sidebar() {
   const pathname = usePathname();
 
   return (
-    <div className="fixed top-0 left-0 z-50 h-screen w-64 bg-white border-r border-gray-100 flex flex-col shadow-sm">
+    <div className="fixed top-0 left-0 z-50 h-screen w-64 bg-white border-r border-gray-100 flex flex-col shadow-sm overflow-y-auto">
       {/* ヘッダー */}
       <div className="p-6 border-b border-gray-200">
         <div className="flex items-center space-x-3">
@@ -42,7 +42,7 @@ export default function Sidebar() {
       </div>
 
       {/* ナビゲーション */}
-      <nav className="flex-1 p-4 space-y-1">
+      <nav className="flex-1 p-4 space-y-1 min-h-0">
         <div className="text-xs font-medium text-gray-400 uppercase tracking-wider mb-3 px-3">
           General
         </div>


### PR DESCRIPTION
## Summary
- 管理画面のサイドバーが画面高さが低い場合にスクロール時に切れる問題を修正
- サイドバー内でスクロールできるよう `overflow-y-auto` を追加

## Test plan
- [ ] 画面の高さを低くして管理画面にアクセス
- [ ] サイドバー内のメニュー項目がすべて表示されることを確認
- [ ] サイドバー内でスクロールが正常に動作することを確認
- [ ] デスクトップ・タブレット・モバイルでの表示確認